### PR TITLE
Add print styles

### DIFF
--- a/css/scss/_base.scss
+++ b/css/scss/_base.scss
@@ -20,12 +20,14 @@ $break4: 1100px;
 // Colors
 $red: #E22C29;
 
+$white: #FFF;
 $lightestGray: #EEE;
 $lighterGray: #CCC;
 $lightGray: #999;
 $gray: #666;
 $darkGray: #555;
 $darkerGray: #333;
+$black: #000;
 
 $bgColor: #FFFEFB;
 $adColor: desaturate(darken($bgColor, 3%), 60%);

--- a/css/scss/style.scss
+++ b/css/scss/style.scss
@@ -615,6 +615,22 @@ ul.listing {
 .highlight .il { color: #0000DD; font-weight: bold } /* Literal.Number.Integer.Long */
 
 
+// print-specific styles
+@media print {
+  /* colors (black on white) */
+  body, h1, h2, h3, h4, .content h1 a, .highlight {
+    color:$black;
+    background-color:$white;
+  }
 
+  /* hide some sections, including comments */
+  section.meta, div#carbonads-container {
+    display:none;
+  }
 
-
+  /* show URL after links */
+  article a:link:after, article a:visited:after {
+    content: " (" attr(href) ") ";
+    font-size: 90%;
+  }
+}


### PR DESCRIPTION
Feross, after getting a lot of use from your Linode articles, I thought I would contribute back these style changes which will make printouts a bit cleaner.

Specific changes:
- Set colors mostly to black on white background
- Remove some sections like meta, prev/next links, ads, and comments
- Add URL after links inside the article

I left the font sizes alone. They could probably be reduced a bit, but it looks pretty good with just these minimal changes.
